### PR TITLE
fixed 'Unable to resolve AccessibilityInfo' #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "url": "https://github.com/jacob-hyde/react-native-editable-table/issues"
   },
   "homepage": "https://github.com/jacob-hyde/react-native-editable-table#readme",
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
     "react": "16.6.0-alpha.8af6728",
     "react-native": "0.57.4"
   },


### PR DESCRIPTION
-  moved react and react-native from dependencies to peerDependencies to avoid version collision with the package user's own copy of dependencies